### PR TITLE
Add Linux TinyCC (tcc) CI cell and C99 CMake dialect.

### DIFF
--- a/.github/workflows/ci-cell.yml
+++ b/.github/workflows/ci-cell.yml
@@ -32,6 +32,10 @@ jobs:
         if: runner.os == 'Linux' && inputs.c-compiler == 'clang'
         run: sudo apt-get update && sudo apt-get install -y clang
 
+      - name: Install TCC (Ubuntu)
+        if: runner.os == 'Linux' && inputs.c-compiler == 'tcc'
+        run: sudo apt-get update && sudo apt-get install -y tcc
+
       - name: Setup MSYS2 MinGW
         if: runner.os == 'Windows' && inputs.c-compiler == 'mingw'
         uses: msys2/setup-msys2@v2
@@ -58,6 +62,14 @@ jobs:
 
           mkdir -p "$DEPS"
 
+          # TinyCC is for the cstring C path only; build deps with GCC/G++.
+          dep_c="${{ inputs.c-compiler }}"
+          dep_cxx="${{ inputs.cpp-compiler }}"
+          if [ "$dep_c" = "tcc" ]; then
+            dep_c=gcc
+            dep_cxx=g++
+          fi
+
           # 1. STLSoft
           git clone --depth 1 https://github.com/synesissoftware/STLSoft "$STLSRC"
           if [ "${{ inputs.c-compiler }}" = "cl" ]; then
@@ -80,8 +92,8 @@ jobs:
           else
             cmake -S "$STLSRC" -B "$STLBUILD" \
               -DCMAKE_BUILD_TYPE="${{ inputs.build-type }}" \
-              -DCMAKE_C_COMPILER="${{ inputs.c-compiler }}" \
-              -DCMAKE_CXX_COMPILER="${{ inputs.cpp-compiler }}" \
+              -DCMAKE_C_COMPILER="$dep_c" \
+              -DCMAKE_CXX_COMPILER="$dep_cxx" \
               -DCMAKE_INSTALL_PREFIX="$DEPS" \
               -DBUILD_EXAMPLES=OFF \
               -DBUILD_TESTING=OFF
@@ -113,8 +125,8 @@ jobs:
           else
             cmake -S "$SHWSRC" -B "$SHWBUILD" \
               -DCMAKE_BUILD_TYPE="${{ inputs.build-type }}" \
-              -DCMAKE_C_COMPILER="${{ inputs.c-compiler }}" \
-              -DCMAKE_CXX_COMPILER="${{ inputs.cpp-compiler }}" \
+              -DCMAKE_C_COMPILER="$dep_c" \
+              -DCMAKE_CXX_COMPILER="$dep_cxx" \
               -DCMAKE_INSTALL_PREFIX="$DEPS" \
               -DCMAKE_PREFIX_PATH="$DEPS" \
               -DBUILD_EXAMPLES=OFF \
@@ -147,8 +159,8 @@ jobs:
           else
             cmake -S "$XTSRC" -B "$XTBUILD" \
               -DCMAKE_BUILD_TYPE="${{ inputs.build-type }}" \
-              -DCMAKE_C_COMPILER="${{ inputs.c-compiler }}" \
-              -DCMAKE_CXX_COMPILER="${{ inputs.cpp-compiler }}" \
+              -DCMAKE_C_COMPILER="$dep_c" \
+              -DCMAKE_CXX_COMPILER="$dep_cxx" \
               -DCMAKE_INSTALL_PREFIX="$DEPS" \
               -DCMAKE_PREFIX_PATH="$DEPS" \
               -DBUILD_EXAMPLES=OFF \
@@ -177,13 +189,21 @@ jobs:
               -DBUILD_EXAMPLES=ON \
               -DBUILD_TESTING=ON
           else
+            # TinyCC: C library + C unit-tests only (deps built with GCC above).
+            build_examples=ON
+            no_cpp_api=OFF
+            if [ "${{ inputs.c-compiler }}" = "tcc" ]; then
+              build_examples=OFF
+              no_cpp_api=ON
+            fi
             cmake -B build -S . \
               -DCMAKE_BUILD_TYPE="${{ inputs.build-type }}" \
               -DCMAKE_C_COMPILER="${{ inputs.c-compiler }}" \
               -DCMAKE_CXX_COMPILER="${{ inputs.cpp-compiler }}" \
               -DCMAKE_PREFIX_PATH="${RUNNER_TEMP}/sis-deps" \
-              -DBUILD_EXAMPLES=ON \
-              -DBUILD_TESTING=ON
+              -DBUILD_EXAMPLES=${build_examples} \
+              -DBUILD_TESTING=ON \
+              -DNO_CSTRING_CPP_API:BOOL=${no_cpp_api}
           fi
 
       - name: Build
@@ -209,6 +229,7 @@ jobs:
   run-examples:
     name: Examples (${{ inputs.cell-id }})
     needs: build
+    if: inputs.c-compiler != 'tcc'
     runs-on: ${{ inputs.os }}
 
     steps:
@@ -271,6 +292,7 @@ jobs:
   test-component:
     name: Component tests (${{ inputs.cell-id }})
     needs: build
+    if: inputs.c-compiler != 'tcc'
     runs-on: ${{ inputs.os }}
 
     steps:
@@ -302,6 +324,7 @@ jobs:
   test-scratch:
     name: Scratch tests (${{ inputs.cell-id }})
     needs: build
+    if: inputs.c-compiler != 'tcc'
     continue-on-error: true
     runs-on: ${{ inputs.os }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,10 @@ jobs:
             os: ubuntu-latest
             c_compiler: gcc
             cpp_compiler: g++
+          - id: linux-tcc
+            os: ubuntu-latest
+            c_compiler: tcc
+            cpp_compiler: g++
           - id: macos-clang
             os: macos-latest
             c_compiler: clang
@@ -72,6 +76,9 @@ jobs:
           - os: ubuntu-latest
             c_compiler: clang
             cpp_compiler: clang++
+          - os: ubuntu-latest
+            c_compiler: tcc
+            cpp_compiler: g++
           - os: macos-latest
             c_compiler: clang
             cpp_compiler: clang++
@@ -88,6 +95,10 @@ jobs:
       - name: Install Clang (Ubuntu)
         if: runner.os == 'Linux' && matrix.c_compiler == 'clang'
         run: sudo apt-get update && sudo apt-get install -y clang
+
+      - name: Install TCC (Ubuntu)
+        if: runner.os == 'Linux' && matrix.c_compiler == 'tcc'
+        run: sudo apt-get update && sudo apt-get install -y tcc
 
       - name: Setup MSYS2 MinGW
         if: runner.os == 'Windows' && matrix.c_compiler == 'mingw'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,15 +3,13 @@ name: CI
 on:
   push:
     branches:
-      - master
-      - dev
       - boilerplate
+      - dev
+      - idiomatic
+      - master
       - rc1
       - rc2
       - rc3
-      - rc4
-      - rc5
-      - update
   pull_request:
 
 concurrency:

--- a/.gitignore
+++ b/.gitignore
@@ -54,12 +54,10 @@ perf_test/
 
 scripts/internal/
 
-/include/b64/
 /include/shwild/
 /include/xcontract/
 /include/xcover/
 /include/xtests/
-/src/b64/
 /src/shwild/
 /src/xcontract/
 /src/xcover/

--- a/.sis/project_name.txt
+++ b/.sis/project_name.txt
@@ -1,0 +1,1 @@
+cstring

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,12 +1,12 @@
 # cstring - Authors <!-- omit in toc -->
 
 
-## Major Contributors
+## Major Contributors:
 
-* Matt Wilson ([mwsis](https://github.com/mwsis))
+* **Matt Wilson** ([mwsis](https://github.com/mwsis));
 
 
-## Defect reports, fixes and suggestions (for which we are very grateful)
+## Defect reports, fixes and suggestions (for which we are very grateful):
 
 * \<none>
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
 * Added **HOW_YOU_CAN_HELP.md**;
 * **TODO.md** — marked `CMAKE_INSTALL_LIBDIR` complete;
 * **run_all_examples.sh**, **run_all_unit_tests.sh**, **run_all_scratch_tests.sh** — coloured list/execute path output (via `tput`);
+* Linux **TinyCC** (**tcc**) CI cell and install-smoke row (via `apt-get install tcc`); deps built with **GCC**/**G++**; **`NO_CSTRING_CPP_API`** and examples skipped for the **tcc** cell;
+* **CMakeLists.txt** — when `CMAKE_C_COMPILER_ID` is **TinyCC**, use `CMAKE_C_STANDARD` **99** (distro **tcc** lacks ISO C17);
 
 
 ## 4.0.13 - 2nd August 2026

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,20 @@
 # cstring - CHANGES <!-- omit in toc -->
 
 
+## 4.0.14-alpha1 - 7th August 2026
+
+* Aligned project boilerplate with **b64** / **Pantheios** (scripts, markdown, CI branches, `.sis`);
+* Added **.sis/project_name.txt**; helper scripts load `ProjectName` for status echoes;
+* CI `on.push.branches` set to lexicographic Pantheios set (`boilerplate`, `dev`, `idiomatic`, `master`, `rc1`–`rc3`);
+* **CMakeLists.txt** — set `CMP0177` for CMake ≥ 3.31;
+* **.gitignore** — removed stray **b64** include/src ignore entries;
+* **README.md** — C++ badge; CI badge alt text; **Introduction**; help links; heading fixes;
+* **AUTHORS.md**, **NEWS.md**, **FAQ.md**, **KNOWN_ISSUES.md** — peer layout/content alignment;
+* Added **HOW_YOU_CAN_HELP.md**;
+* **TODO.md** — marked `CMAKE_INSTALL_LIBDIR` complete;
+* **run_all_examples.sh**, **run_all_unit_tests.sh**, **run_all_scratch_tests.sh** — coloured list/execute path output (via `tput`);
+
+
 ## 4.0.13 - 2nd August 2026
 
 * Modular GitHub Actions CI (**ci.yml** + **ci-cell.yml**), with install-smoke and MinGW cells;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 # Purpose:  Top-level CMake lists file for cstring
 #
 # Created:  21st December 2023
-# Updated:  2nd August 2026
+# Updated:  6th August 2026
 #
 # ######################################################################## #
 
@@ -14,6 +14,9 @@
 # CMake
 
 cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.31")
+	cmake_policy(SET CMP0177 NEW)
+endif()
 
 # require out-of-source builds
 file(TO_CMAKE_PATH "${CMAKE_CURRENT_BINARY_DIR}/CMakeLists.txt" LOC_PATH)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 # Purpose:  Top-level CMake lists file for cstring
 #
 # Created:  21st December 2023
-# Updated:  6th August 2026
+# Updated:  7th August 2026
 #
 # ######################################################################## #
 
@@ -66,6 +66,13 @@ set(CMAKE_C_EXTENSIONS ON) # GNU extensions and POSIX standard
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS ON)
+
+# Distro TinyCC (e.g. Ubuntu `tcc` 0.9.27) does not implement ISO C17; keep
+# a portable C99 dialect so the Linux TCC CI cell can exercise the C path.
+if(CMAKE_C_COMPILER_ID STREQUAL "TinyCC")
+
+	set(CMAKE_C_STANDARD 99)
+endif()
 
 if(MSVC)
 

--- a/Doxyfile
+++ b/Doxyfile
@@ -2,7 +2,7 @@
 
 PROJECT_NAME           = "cstring"
 PROJECT_BRIEF          = "Extensible C-style strings and vectors of such, for Unix and Windows"
-PROJECT_NUMBER         = 4.0.13
+PROJECT_NUMBER         = 4.0.14-alpha1
 
 # Prefer SIS_CMAKE_BUILD_DIR-aligned output (same convention as Diagnosticism).
 # ./dox/ remains gitignored for legacy/local runs that override OUTPUT_DIRECTORY.

--- a/FAQ.md
+++ b/FAQ.md
@@ -8,9 +8,11 @@ it will be used to create one.
 ## Table of Contents <!-- omit in toc -->
 
 - [Q1: "How do I build cstring?"](#q1-how-do-i-build-cstring)
-- [Q2: "Does cstring have its own unit-tests?"](#q2-does-cstring-have-its-own-unit-tests)
-- [Q3: "How do I build without the C++ examples and tests?"](#q3-how-do-i-build-without-the-c-examples-and-tests)
-- [Q4: "Where are the examples?"](#q4-where-are-the-examples)
+- [Q2: "How do I install cstring?"](#q2-how-do-i-install-cstring)
+- [Q3: "How do I use cstring?"](#q3-how-do-i-use-cstring)
+- [Q4: "Does cstring have its own unit-tests?"](#q4-does-cstring-have-its-own-unit-tests)
+- [Q5: "How do I build without the C++ examples and tests?"](#q5-how-do-i-build-without-the-c-examples-and-tests)
+- [Q6: "Where are the examples?"](#q6-where-are-the-examples)
 
 
 # FAQs: <!-- omit in toc -->
@@ -37,7 +39,48 @@ $ ./prepare_cmake.sh -m
 Execute `$ ./prepare_cmake.sh --help` for the full set of options.
 
 
-## Q2: "Does cstring have its own unit-tests?"
+## Q2: "How do I install cstring?"
+
+See [INSTALL.md](./INSTALL.md) for details of how to install **cstring**.
+
+
+## Q3: "How do I use cstring?"
+
+Include **cstring/cstring.h** (and **cstring/cstring.vector.h** where needed)
+and link against **libcstring** (the **CMake** target is `cstring::core`).
+Create and destroy instances with `cstring_create()` / `cstring_destroy()`,
+and mutate with `cstring_assign()`, `cstring_append()`, and related APIs.
+
+A minimal sketch:
+
+```c
+#include <cstring/cstring.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(void)
+{
+    cstring_t cs;
+    CSTRING_RC rc = cstring_create(&cs, "Hello");
+
+    if (CSTRING_RC_SUCCESS != rc)
+    {
+        return EXIT_FAILURE;
+    }
+
+    printf("%s\n", cs.ptr);
+
+    cstring_destroy(&cs);
+
+    return EXIT_SUCCESS;
+}
+```
+
+See [INSTALL.md](./INSTALL.md) and the examples under **examples/**.
+
+
+## Q4: "Does cstring have its own unit-tests?"
 
 Yes. Automated tests live under:
 
@@ -50,7 +93,7 @@ and run with **run_all_unit_tests.sh** (and **CTest** where configured). Tests
 require **STLSoft** and **xTests** (and may optionally recognise **shwild**).
 
 
-## Q3: "How do I build without the C++ examples and tests?"
+## Q5: "How do I build without the C++ examples and tests?"
 
 Pass `--no-cpp` (or `-C`) to **prepare_cmake.sh**, which sets CMake
 `NO_CSTRING_CPP_API=ON`. That omits C++ examples and remaining C++ tests.
@@ -59,7 +102,7 @@ The **C** unit-tests still require **STLSoft** and **xTests** unless you also
 pass `--disable-testing` / `-T`.
 
 
-## Q4: "Where are the examples?"
+## Q6: "Where are the examples?"
 
 Examples live under **examples/** (`c/` and `cpp/`), each with a short
 **README.md**. They are built when `BUILD_EXAMPLES` is on (the default); omit

--- a/HOW_YOU_CAN_HELP.md
+++ b/HOW_YOU_CAN_HELP.md
@@ -1,0 +1,70 @@
+# cstring - How You Can Help <!-- omit in toc -->
+
+
+## Table of Contents <!-- omit in toc -->
+
+There are several ways in which you can help the **cstring** project:
+
+- [Defect reports](#defect-reports)
+- [Feature requests](#feature-requests)
+- [Submit your own extensions](#submit-your-own-extensions)
+- [Sponsor development](#sponsor-development)
+- [Write articles, blog-posts about your experiences](#write-articles-blog-posts-about-your-experiences)
+
+
+## Defect reports
+
+We're keen to hear of any problems you have in building and, especially, in
+using the library.
+
+Please submit an issue at:
+
+  https://github.com/synesissoftware/cstring/issues
+
+Please help us to help you by submitting as much information about the
+problem as you think is relevant, including:
+
+* the compiler you're using;
+* the architecture and operating system you're targeting;
+* the version of **cstring**;
+* the version of **STLSoft** / **xTests** (when building tests);
+* whether you're building using **CMake** or via an IDE;
+* a section of the build output, including the warnings/errors involved;
+
+
+## Feature requests
+
+If there are features that you think would enhance the library, please feel
+free to share your ideas.
+
+You can either submit an issue:
+
+  https://github.com/synesissoftware/cstring/issues
+
+Or provide your suggested work via a pull-request:
+
+  https://github.com/synesissoftware/cstring/pulls
+
+
+## Submit your own extensions
+
+If you have developed extensions or improvements and wish to contribute them
+back to the project so others can benefit from your work, please open an
+issue or pull request at:
+
+  https://github.com/synesissoftware/cstring
+
+
+## Sponsor development
+
+If you value the diligence and effort that's gone into bringing you this
+production-quality software, please get in contact via
+https://www.synesis.com.au/contact.html
+
+
+## Write articles, blog-posts about your experiences
+
+If you've written articles or blogged about **cstring**, let us know.
+
+
+<!-- ########################### end of file ########################### -->

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -1,7 +1,12 @@
 # cstring - Known Issues <!-- omit in toc -->
 
 
-## cstring 4 Known Issues
+## cstring 4.0.x Known Issues
+
+* \<none>
+
+
+## cstring 4.0.x Suspected Issues
 
 * \<none>
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,29 +1,27 @@
 # cstring - News <!-- omit in toc -->
 
 
-| Date                  | News Item                                                     |
-| --------------------- | ------------------------------------------------------------- |
-| 2nd August 2026       | Release of [cstring 4.0.13](https://github.com/synesissoftware/cstring/releases/tag/4.0.13) (modular CI, examples, Doxygen, documentation) |
-| 2nd September 2025    | Release of [cstring 4.0.12](https://github.com/synesissoftware/cstring/releases/tag/4.0.12) |
-| 23rd February 2025    | Release of cstring 4.0.11                                     |
-| 25th October 2024     | Release of cstring 4.0.10                                     |
-| Available from [**cstring** project on GitHub](https://synesissoftware.com/cstring):  |
-| 28th January 2024     | Release of cstring 4.0.9                                      |
-| 12th January 2024     | Release of cstring 4.0.8                                      |
-| Available from **http://synesis.com.au/software/cstring**:                            |
-| 20th February 2012    | Release of 3.6.2                                              |
-| 24th January 2012     | Release of 3.6.1                                              |
-| 22nd January 2012     | Release of 3.5.4                                              |
-| 11th January 2010     | Release of 3.5.3                                              |
-| 11th July 2009        | Release of 3.5.2                                              |
-| 10th July 2009        | Release of 3.5.1                                              |
-| 4th May 2008          | Release of 3.4.4                                              |
-| 26th January 2007     | Release of 3.4.3                                              |
-| 30th April 2006       | Release of 3.4.2                                              |
-| 7th October 2005      | Release of 3.4.1                                              |
-| 8th August 2005       | Release of 3.3.1                                              |
-| 29th July 2005        | Release of 3.2.1                                              |
+| Date               | News Item                                                                                                                      |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| 7th August 2026    | Release of [cstring 4.0.14-alpha1](https://github.com/synesissoftware/cstring/releases/tag/4.0.14-alpha1) (boilerplate alignment with **b64** / **Pantheios**) |
+| 2nd August 2026    | Release of [cstring 4.0.13](https://github.com/synesissoftware/cstring/releases/tag/4.0.13) (modular CI, examples, Doxygen, documentation) |
+| 2nd September 2025 | Release of [cstring 4.0.12](https://github.com/synesissoftware/cstring/releases/tag/4.0.12)                                     |
+| 23rd February 2025 | Release of cstring 4.0.11 |
+| 25th October 2024  | Release of cstring 4.0.10 |
+| 28th January 2024  | Release of cstring 4.0.9  |
+| 12th January 2024  | Release of cstring 4.0.8  |
+| 20th February 2012 | Release of 3.6.2          |
+| 24th January 2012  | Release of 3.6.1          |
+| 22nd January 2012  | Release of 3.5.4          |
+| 11th January 2010  | Release of 3.5.3          |
+| 11th July 2009     | Release of 3.5.2          |
+| 10th July 2009     | Release of 3.5.1          |
+| 4th May 2008       | Release of 3.4.4          |
+| 26th January 2007  | Release of 3.4.3          |
+| 30th April 2006    | Release of 3.4.2          |
+| 7th October 2005   | Release of 3.4.1          |
+| 8th August 2005    | Release of 3.3.1          |
+| 29th July 2005     | Release of 3.2.1          |
 
 
 <!-- ########################### end of file ########################### -->
-

--- a/README.md
+++ b/README.md
@@ -4,23 +4,24 @@
 
 
 ![C](https://img.shields.io/badge/C-00599C?style=flat&logo=c&logoColor=white)
+![C++](https://img.shields.io/badge/C%2B%2B-00599C?style=flat&logo=c%2B%2B&logoColor=white)
 [![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![GitHub release](https://img.shields.io/github/v/release/synesissoftware/cstring.svg)](https://github.com/synesissoftware/cstring/releases/latest)
 [![Last Commit](https://img.shields.io/github/last-commit/synesissoftware/cstring)](https://github.com/synesissoftware/cstring/commits/master)
-[![CMake on multiple platforms](https://github.com/synesissoftware/cstring/actions/workflows/ci.yml/badge.svg)](https://github.com/synesissoftware/cstring/actions/workflows/ci.yml)
-
+[![CI](https://github.com/synesissoftware/cstring/actions/workflows/ci.yml/badge.svg)](https://github.com/synesissoftware/cstring/actions/workflows/ci.yml)
 
 
 ## Table of Contents <!-- omit in toc -->
 
+- [Introduction](#introduction)
 - [Installation](#installation)
 - [Components](#components)
   - [Types](#types)
   - [String API](#string-api)
     - [Status and capacity](#status-and-capacity)
     - [Creation/destruction functions](#creationdestruction-functions)
-    - [Modification functions\*\*](#modification-functions)
-    - [File functions\*\*](#file-functions)
+    - [Modification functions](#modification-functions)
+    - [File functions](#file-functions)
   - [Vector API](#vector-api)
 - [Examples](#examples)
 - [Project Information](#project-information)
@@ -29,6 +30,13 @@
   - [Dependencies](#dependencies)
   - [Related projects](#related-projects)
   - [License](#license)
+
+
+## Introduction
+
+**cstring** is a small, standalone library that provides extensible C-style string instances and extensible arrays of such, for Unix and Windows.
+
+The **C** API has no non-standard dependencies. Optional C++ examples and remaining C++ tests may be omitted with `--no-cpp` / `NO_CSTRING_CPP_API`. Building tests requires **STLSoft** and **xTests** (and may optionally recognise **shwild**).
 
 
 ## Installation
@@ -89,7 +97,7 @@ Defined in **cstring/cstring.h**:
 * `cstring_createLenEx()` — as `cstring_createEx()`, from a fixed number of characters;
 * `cstring_destroy()` — releases resources and resets the instance;
 
-#### Modification functions**
+#### Modification functions
 
 * `cstring_assign()` — assigns a C-style string (may reallocate);
 * `cstring_assignLen()` — assigns a fixed character count (embedded NULs allowed);
@@ -104,7 +112,7 @@ Defined in **cstring/cstring.h**:
 * `cstring_truncate()` — shortens the logical length (capacity unchanged);
 * `cstring_swap()` — swaps the contents of two instances;
 
-#### File functions**
+#### File functions
 
 * `cstring_readline()` — reads a line of text from the given text stream into the instance;
 * `cstring_write()` — writes the string to the given text stream;
@@ -143,12 +151,17 @@ Examples live under **examples/** (`c/` and `cpp/`), each with a short **README.
 
 ### Where to get help
 
-[GitHub Page](https://github.com/synesissoftware/cstring "GitHub Page")
+* [GitHub Page](https://github.com/synesissoftware/cstring)
+* [GitHub Issues](https://github.com/synesissoftware/cstring/issues)
+* [FAQ.md](./FAQ.md)
+* [HOW_YOU_CAN_HELP.md](./HOW_YOU_CAN_HELP.md)
 
 
 ### Contribution guidelines
 
 Defect reports, feature requests, and pull requests are welcome on https://github.com/synesissoftware/cstring.
+
+See also [HOW_YOU_CAN_HELP.md](./HOW_YOU_CAN_HELP.md).
 
 
 ### Dependencies

--- a/TODO.md
+++ b/TODO.md
@@ -40,6 +40,7 @@
   * [x] ~~~macOS~~~ - ✅;
   * [x] ~~~Unix (ubuntu)~~~ - ✅;
   * [x] ~~~Windows~~~ - ✅;
+  * [x] ~~~Linux TinyCC (**tcc**) cell + install-smoke~~~ - ✅;
   * [ ] Debug configuration;
   * [ ] Release configuration;
   * [ ] exercise `--no-cpp` / `--no-shwild` permutations beyond the current jobs;

--- a/TODO.md
+++ b/TODO.md
@@ -29,7 +29,7 @@
 * [x] ~~~Boilerplate: **INSTALL.md**, **FAQ.md**, **KNOWN_ISSUES.md**, **AUTHORS.md** layout~~~ - ✅;
 * [ ] CMake:
   * [x] ~~~custom definitions: `_BUILD_AS_UNIX` / `_BUILD_AS_WIN32`~~~ - ✅;
-  * [ ] `CMAKE_INSTALL_LIBDIR` (export config still references `LIB_INSTALL_DIR` in one path);
+  * [x] ~~~`CMAKE_INSTALL_LIBDIR` (replaces legacy `LIB_INSTALL_DIR`)~~~ - ✅;
   * [x] ~~~**CTest**~~~ - ✅;
   * [ ] build DLL on Windows;
   * [x] ~~~`/MT` build option for Visual C++ (`--msvc-mt` / `MSVC_USE_MT`)~~~ - ✅;

--- a/build_cmake.sh
+++ b/build_cmake.sh
@@ -6,6 +6,8 @@ Basename=$(basename "$ScriptPath")
 CMakeDir=${SIS_CMAKE_BUILD_DIR:-$Dir/_build}
 [[ -n "$MSYSTEM" ]] && DefaultMakeCmd=mingw32-make.exe || DefaultMakeCmd=make
 MakeCmd=${SIS_CMAKE_MAKE_COMMAND:-${SIS_CMAKE_COMMAND:-$DefaultMakeCmd}}
+ProjectNameFile="$Dir/.sis/project_name.txt"
+ProjectName=$(tr -d '[:space:]' < "$ProjectNameFile")
 
 IgnoreRemainingFlagsAndOptions=0
 Targets=()
@@ -103,10 +105,10 @@ else
 
     if [ -z "$Targets" ]; then
 
-      echo "Executing build (via command \`$MakeCmd\`)"
+      echo "Executing build for ${ProjectName} (via command \`$MakeCmd\`)"
     else
 
-      echo "Executing build (via command \`$MakeCmd\`) with specific target(s) $(join_by , "${Targets[@]}")"
+      echo "Executing build for ${ProjectName} (via command \`$MakeCmd\`) with specific target(s) $(join_by , "${Targets[@]}")"
     fi
 
     $MakeCmd ${Targets[*]}

--- a/clean_cmake.sh
+++ b/clean_cmake.sh
@@ -6,6 +6,8 @@ Basename=$(basename "$ScriptPath")
 CMakeDir=${SIS_CMAKE_BUILD_DIR:-$Dir/_build}
 [[ -n "$MSYSTEM" ]] && DefaultMakeCmd=mingw32-make.exe || DefaultMakeCmd=make
 MakeCmd=${SIS_CMAKE_MAKE_COMMAND:-${SIS_CMAKE_COMMAND:-$DefaultMakeCmd}}
+ProjectNameFile="$Dir/.sis/project_name.txt"
+ProjectName=$(tr -d '[:space:]' < "$ProjectNameFile")
 
 
 # ##########################################################
@@ -69,7 +71,7 @@ else
     exit 1
   else
 
-    echo "Cleaning build (via command \`$MakeCmd clean\`)"
+    echo "Cleaning ${ProjectName} build (via command \`$MakeCmd clean\`)"
 
     $MakeCmd clean
     status=$?

--- a/ctest_cmake.sh
+++ b/ctest_cmake.sh
@@ -6,6 +6,8 @@ Basename=$(basename "$ScriptPath")
 CMakeDir=${SIS_CMAKE_BUILD_DIR:-$Dir/_build}
 [[ -n "$MSYSTEM" ]] && DefaultMakeCmd=mingw32-make.exe || DefaultMakeCmd=make
 MakeCmd=${SIS_CMAKE_MAKE_COMMAND:-${SIS_CMAKE_COMMAND:-$DefaultMakeCmd}}
+ProjectNameFile="$Dir/.sis/project_name.txt"
+ProjectName=$(tr -d '[:space:]' < "$ProjectNameFile")
 
 CMakeVerbose=
 RunMake=1
@@ -74,7 +76,7 @@ status=0
 
 if [ $RunMake -ne 0 ]; then
 
-  echo "Executing build (via command \`$MakeCmd\`) and then running all component and unit test programs"
+  echo "Executing build for ${ProjectName} (via command \`$MakeCmd\`) and then running all component and unit test programs"
 
   mkdir -p $CMakeDir || exit 1
 

--- a/generate_doxygen.sh
+++ b/generate_doxygen.sh
@@ -11,6 +11,8 @@ ScriptPath=$0
 Dir=$(cd "$(dirname "$ScriptPath")" && pwd)
 Basename=$(basename "$ScriptPath")
 CMakeDir=${SIS_CMAKE_BUILD_DIR:-$Dir/_build}
+ProjectNameFile="$Dir/.sis/project_name.txt"
+ProjectName=$(tr -d '[:space:]' < "$ProjectNameFile")
 
 
 # ##########################################################
@@ -75,7 +77,7 @@ mkdir -p "${CMakeDir}/doxygen"
   echo "OUTPUT_DIRECTORY = ${CMakeDir}/doxygen"
 } | doxygen -
 
-echo "API documentation written to ${CMakeDir}/doxygen/html/index.html"
+echo "${ProjectName} API documentation written to ${CMakeDir}/doxygen/html/index.html"
 
 
 # ############################## end of file ############################# #

--- a/include/cstring/cstring.h
+++ b/include/cstring/cstring.h
@@ -4,7 +4,7 @@
  * Purpose: Definition of the cstring.core API.
  *
  * Created: 16th June 1994
- * Updated: 2nd August 2026
+ * Updated: 7th August 2026
  *
  * Home:    http://synesis.com.au/software/
  *
@@ -55,8 +55,8 @@
 #ifndef CSTRING_DOCUMENTATION_SKIP_SECTION
 # define CSTRING_VER_CSTRING_H_CSTRING_MAJOR    3
 # define CSTRING_VER_CSTRING_H_CSTRING_MINOR    11
-# define CSTRING_VER_CSTRING_H_CSTRING_REVISION 10
-# define CSTRING_VER_CSTRING_H_CSTRING_EDIT     82
+# define CSTRING_VER_CSTRING_H_CSTRING_REVISION 11
+# define CSTRING_VER_CSTRING_H_CSTRING_EDIT     83
 #endif /* !CSTRING_DOCUMENTATION_SKIP_SECTION */
 
 /** \def CSTRING_VER_MAJOR
@@ -111,6 +111,8 @@
 # define CSTRING_VER_4_0_10     0x04000aff
 # define CSTRING_VER_4_0_11     0x04000bff
 # define CSTRING_VER_4_0_12     0x04000cff
+# define CSTRING_VER_4_0_13     0x04000dff
+# define CSTRING_VER_4_0_14_A1  0x04000e41
 #endif /* !CSTRING_DOCUMENTATION_SKIP_SECTION */
 
 /** \def CSTRING_VER_MAJOR
@@ -131,8 +133,8 @@
 
 #define CSTRING_VER_MAJOR                                   4
 #define CSTRING_VER_MINOR                                   0
-#define CSTRING_VER_PATCH                                   13
-#define CSTRING_VER_ALPHABETA                               0xFF
+#define CSTRING_VER_PATCH                                   14
+#define CSTRING_VER_ALPHABETA                               0x41
 
 #define CSTRING_VER \
     (0\

--- a/prepare_cmake.sh
+++ b/prepare_cmake.sh
@@ -14,6 +14,9 @@ else
 fi
 MakeCmd=${SIS_CMAKE_MAKE_COMMAND:-${SIS_CMAKE_COMMAND:-$DefaultMakeCmd}}
 
+ProjectNameFile="$Dir/.sis/project_name.txt"
+ProjectName=$(tr -d '[:space:]' < "$ProjectNameFile")
+
 Configuration=Release
 ExamplesDisabled=0
 MSVC_MT=0
@@ -162,7 +165,7 @@ mkdir -p $CMakeDir || exit 1
 
 cd $CMakeDir
 
-echo "Executing CMake (in ${CMakeDir})"
+echo "Executing CMake for ${ProjectName} (in ${CMakeDir})"
 
 if [ $ExamplesDisabled -eq 0 ]; then CMakeBuildExamplesFlag="ON" ; else CMakeBuildExamplesFlag="OFF" ; fi
 if [ $MSVC_MT -eq 0 ]; then CMakeMsvcMtFlag="OFF" ; else CMakeMsvcMtFlag="ON" ; fi
@@ -205,7 +208,7 @@ status=0
 
 if [ $RunMake -ne 0 ]; then
 
-  echo "Executing build (via command \`$MakeCmd\`)"
+  echo "Executing build for ${ProjectName} (via command \`$MakeCmd\`)"
 
   $MakeCmd
   status=$?

--- a/remove_cmake_artefacts.sh
+++ b/remove_cmake_artefacts.sh
@@ -4,6 +4,8 @@ ScriptPath=$0
 Dir=$(cd $(dirname "$ScriptPath"); pwd)
 Basename=$(basename "$ScriptPath")
 CMakeDir=${SIS_CMAKE_BUILD_DIR:-$Dir/_build}
+ProjectNameFile="$Dir/.sis/project_name.txt"
+ProjectName=$(tr -d '[:space:]' < "$ProjectNameFile")
 
 Directories=(
   CMakeFiles
@@ -98,7 +100,7 @@ if [ ! -d "$CMakeDir" ]; then
   exit 0
 else
 
-  echo "Removing all cmake artefacts in '$CMakeDir'"
+  echo "Removing all ${ProjectName} cmake artefacts in '$CMakeDir'"
 
   num_dirs_removed=0
   num_files_removed=0

--- a/run_all_examples.sh
+++ b/run_all_examples.sh
@@ -6,9 +6,29 @@ Basename=$(basename "$ScriptPath")
 CMakeDir=${SIS_CMAKE_BUILD_DIR:-$Dir/_build}
 [[ -n "$MSYSTEM" ]] && DefaultMakeCmd=mingw32-make.exe || DefaultMakeCmd=make
 MakeCmd=${SIS_CMAKE_MAKE_COMMAND:-${SIS_CMAKE_COMMAND:-$DefaultMakeCmd}}
+ProjectNameFile="$Dir/.sis/project_name.txt"
+ProjectName=$(tr -d '[:space:]' < "$ProjectNameFile")
 
 ListOnly=0
 RunMake=1
+
+
+# ##########################################################
+# colours
+
+if command -v tput > /dev/null; then
+
+  RbEnvClr_Blue=${FG_BLUE:-$(tput setaf 4)}
+  RbEnvClr_Red=${FG_BLUE:-$(tput setaf 1)}
+  RbEnvClr_Bold=${FD_BOLD:-$(tput bold)}
+  RbEnvClr_None=${FD_NONE:-$(tput sgr0)}
+else
+
+  RbEnvClr_Blue=
+  RbEnvClr_Red=
+  RbEnvClr_Bold=
+  RbEnvClr_None=
+fi
 
 
 # ##########################################################
@@ -76,7 +96,7 @@ if [ $RunMake -ne 0 ]; then
 
   if [ $ListOnly -eq 0 ]; then
 
-    echo "Executing build (via command \`$MakeCmd\`) and then running all example programs"
+    echo "Executing build (via command \`$MakeCmd\`) and then running all ${ProjectName} example programs"
 
     mkdir -p $CMakeDir || exit 1
 
@@ -99,10 +119,10 @@ if [ $status -eq 0 ]; then
 
   if [ $ListOnly -ne 0 ]; then
 
-    echo "Listing all example programs"
+    echo "Listing all ${ProjectName} example programs"
   else
 
-    echo "Running all example programs"
+    echo "Running all ${ProjectName} example programs"
   fi
 
   for f in $(find $CMakeDir -type f '(' -name 'example.c.*' -o -name 'example.cpp.*' ')' -exec test -x {} \; -print)
@@ -110,13 +130,13 @@ if [ $status -eq 0 ]; then
 
     if [ $ListOnly -ne 0 ]; then
 
-      echo "would execute $f:"
+      echo "would execute $RbEnvClr_Blue$RbEnvClr_Bold$f$RbEnvClr_None:"
 
       continue
     fi
 
     echo
-    echo "executing $f:"
+    echo "executing $RbEnvClr_Blue$RbEnvClr_Bold$f$RbEnvClr_None:"
 
     $f
   done

--- a/run_all_scratch_tests.sh
+++ b/run_all_scratch_tests.sh
@@ -6,10 +6,30 @@ Basename=$(basename "$ScriptPath")
 CMakeDir=${SIS_CMAKE_BUILD_DIR:-$Dir/_build}
 [[ -n "$MSYSTEM" ]] && DefaultMakeCmd=mingw32-make.exe || DefaultMakeCmd=make
 MakeCmd=${SIS_CMAKE_MAKE_COMMAND:-${SIS_CMAKE_COMMAND:-$DefaultMakeCmd}}
+ProjectNameFile="$Dir/.sis/project_name.txt"
+ProjectName=$(tr -d '[:space:]' < "$ProjectNameFile")
 
 ListOnly=0
 RunMake=1
 Verbosity=${XTESTS_VERBOSITY:-${TEST_VERBOSITY:-3}}
+
+
+# ##########################################################
+# colours
+
+if command -v tput > /dev/null; then
+
+  RbEnvClr_Blue=${FG_BLUE:-$(tput setaf 4)}
+  RbEnvClr_Red=${FG_BLUE:-$(tput setaf 1)}
+  RbEnvClr_Bold=${FD_BOLD:-$(tput bold)}
+  RbEnvClr_None=${FD_NONE:-$(tput sgr0)}
+else
+
+  RbEnvClr_Blue=
+  RbEnvClr_Red=
+  RbEnvClr_Bold=
+  RbEnvClr_None=
+fi
 
 
 # ##########################################################
@@ -85,7 +105,7 @@ if [ $RunMake -ne 0 ]; then
 
   if [ $ListOnly -eq 0 ]; then
 
-    echo "Executing build (via command \`$MakeCmd\`) and then running all scratch (and performance) test programs"
+    echo "Executing build (via command \`$MakeCmd\`) and then running all ${ProjectName} scratch (and performance) test programs"
 
     mkdir -p $CMakeDir || exit 1
 
@@ -108,10 +128,10 @@ if [ $status -eq 0 ]; then
 
   if [ $ListOnly -ne 0 ]; then
 
-    echo "Listing all scratch (and performance) test programs"
+    echo "Listing all ${ProjectName} scratch (and performance) test programs"
   else
 
-    echo "Running all scratch (and performance) test programs"
+    echo "Running all ${ProjectName} scratch (and performance) test programs"
   fi
 
   for f in $(find $CMakeDir -type f '(' -name 'test_scratch*' -o -name 'test.scratch.*' -o -name 'test_performance*' -o -name 'test.performance.*' ')' -exec test -x {} \; -print)
@@ -119,7 +139,7 @@ if [ $status -eq 0 ]; then
 
     if [ $ListOnly -ne 0 ]; then
 
-      echo "would execute $f:"
+      echo "would execute $RbEnvClr_Blue$RbEnvClr_Bold$f$RbEnvClr_None:"
 
       continue
     fi
@@ -130,7 +150,7 @@ if [ $status -eq 0 ]; then
     fi
     if [ $Verbosity -ge 2 ]; then
 
-      echo "executing $f:"
+      echo "executing $RbEnvClr_Blue$RbEnvClr_Bold$f$RbEnvClr_None:"
     fi
 
     if $f; then

--- a/run_all_unit_tests.sh
+++ b/run_all_unit_tests.sh
@@ -6,12 +6,32 @@ Basename=$(basename "$ScriptPath")
 CMakeDir=${SIS_CMAKE_BUILD_DIR:-$Dir/_build}
 [[ -n "$MSYSTEM" ]] && DefaultMakeCmd=mingw32-make.exe || DefaultMakeCmd=make
 MakeCmd=${SIS_CMAKE_MAKE_COMMAND:-${SIS_CMAKE_COMMAND:-$DefaultMakeCmd}}
+ProjectNameFile="$Dir/.sis/project_name.txt"
+ProjectName=$(tr -d '[:space:]' < "$ProjectNameFile")
 
 ListOnly=0
 RunMake=1
 UnitOnly=0
 ComponentOnly=0
 Verbosity=${XTESTS_VERBOSITY:-${TEST_VERBOSITY:-3}}
+
+
+# ##########################################################
+# colours
+
+if command -v tput > /dev/null; then
+
+  RbEnvClr_Blue=${FG_BLUE:-$(tput setaf 4)}
+  RbEnvClr_Red=${FG_BLUE:-$(tput setaf 1)}
+  RbEnvClr_Bold=${FD_BOLD:-$(tput bold)}
+  RbEnvClr_None=${FD_NONE:-$(tput sgr0)}
+else
+
+  RbEnvClr_Blue=
+  RbEnvClr_Red=
+  RbEnvClr_Bold=
+  RbEnvClr_None=
+fi
 
 
 # ##########################################################
@@ -119,7 +139,7 @@ if [ $RunMake -ne 0 ]; then
 
   if [ $ListOnly -eq 0 ]; then
 
-    echo "Executing build (via command \`$MakeCmd\`) and then running all ${TestKindDescription} programs"
+    echo "Executing build (via command \`$MakeCmd\`) and then running all ${ProjectName} ${TestKindDescription} programs"
 
     mkdir -p $CMakeDir || exit 1
 
@@ -144,10 +164,10 @@ if [ $status -eq 0 ]; then
 
   if [ $ListOnly -ne 0 ]; then
 
-    echo "Listing all ${TestKindDescription} programs"
+    echo "Listing all ${ProjectName} ${TestKindDescription} programs"
   else
 
-    echo "Running all ${TestKindDescription} programs"
+    echo "Running all ${ProjectName} ${TestKindDescription} programs"
   fi
 
   if [ $UnitOnly -ne 0 ]; then
@@ -166,7 +186,7 @@ if [ $status -eq 0 ]; then
 
     if [ $ListOnly -ne 0 ]; then
 
-      echo "would execute $f:"
+      echo "would execute $RbEnvClr_Blue$RbEnvClr_Bold$f$RbEnvClr_None:"
 
       continue
     fi
@@ -177,7 +197,7 @@ if [ $status -eq 0 ]; then
     fi
     if [ $Verbosity -ge 2 ]; then
 
-      echo "executing $f:"
+      echo "executing $RbEnvClr_Blue$RbEnvClr_Bold$f$RbEnvClr_None:"
     fi
 
     if $f --verbosity=$Verbosity; then


### PR DESCRIPTION
Exercise the C library and unit tests via apt-installed tcc, building deps with GCC/G++ and skipping C++ examples/tests for that cell.